### PR TITLE
Add more command line options to "git abc list"

### DIFF
--- a/git-abc
+++ b/git-abc
@@ -475,11 +475,23 @@ abc_list()
 {
 	local range flag commit subject
 	local list='--candidates'
+	local format=''
+	local reverse=''
 
-	if [[ "$1" =~ ^- ]] && [[ "$1" != '--' ]]; then
-		list=$1
+	while [[ "$1" =~ ^- ]] && [[ "$1" != '--' ]]; do
+		case "$1" in
+		--candidates|--xcandidates|--deferred|--pending|--rejected| \
+		--backported|--backported-non-trivial|--backported-cherry-picks| \
+		--downstream-only) list=$1;;
+
+		--oneline|--pretty|--pretty=*|--format=*) format=$1 ;;
+
+		--reverse) reverse=$1 ;;
+		*) die_error "Unknown option '$1' passed to list" ;;
+		esac
 		shift
-	fi
+	done
+
 	abc_get_limits "$@"
 
 	case "$list" in
@@ -492,17 +504,25 @@ abc_list()
 	--backported-non-trivial)	range="$ABC_UPSTREAM..$ABC_DOWNSTREAM" flag=ABC_UPSTREAM;;
 	--backported-cherry-picks)	range="$ABC_UPSTREAM..$ABC_DOWNSTREAM" flag=ABC_CHERRYPICK;;
 	--downstream-only)		range="$ABC_UPSTREAM..$ABC_DOWNSTREAM" flag=ABC_ONLY_DOWNSTREAM;;
-	*)
-		die_error "Unknown option '$list' passed to list"
-		;;
+	*) die_error "huh?" ;;
 	esac
 
-	git log --notes --pretty='%h %s' --grep="^$flag" "$range" |
+	# shellcheck disable=SC2086
+	git log $reverse --notes --pretty='%h %s' --grep="^$flag" "$range" |
 	while read -r commit subject; do
 		if abc_should_highlight "$commit"; then
-			echo "$(abc_highlight "$commit") $subject"
-		elif [[ "$ABC_ONLY_FIXES" != 'y' ]]; then
+			if [ -z "$format" ]; then
+				echo "$(abc_highlight "$commit") $subject"
+				continue
+			fi
+		elif [[ "$ABC_ONLY_FIXES" == 'y' ]]; then
+			continue
+		fi
+
+		if [ -z "$format" ]; then
 			echo "$commit $subject"
+		else
+			git log -1 "$format" "$commit"
 		fi
 	done
 }
@@ -1069,7 +1089,7 @@ case "$cmd" in
 find)				abc_find "$@";;
 list)				abc_list "$@";;
 list-fixes)			ABC_ONLY_FIXES=y abc_list "$@";;
-pick-list)			abc_list --pending "$@" | awk '{print$1}' | tac;;
+pick-list)			abc_list --pending --pretty=%H --reverse "$@";;
 select)				abc_select "$@";;
 flag)				abc_flag "$@";;
 reject)				abc_flag --rejected "$@";;

--- a/man/man1/git-abc.1
+++ b/man/man1/git-abc.1
@@ -46,23 +46,22 @@ To speed it up, as well as other git-abc commands, it's recommended to enable co
 Also, don't forget to create the initial commit-graph file with 'git commit-graph write'.
 .RE
 .PP
-list|list-fixes [<option>] [<upstream> [<downstream>]]
+list|list-fixes [<options>] [<upstream> [<downstream>]]
 .RS 4
 .nf
-where <option> is one of the following
---candidates|--deferred|--pending|--rejected|
---downstream-only|
---backported|--backported-non-trivial|--backported-cherry-picks
+Options specify which commits to list and how to present them.
 .fi
 .sp
-List backport candidates (--candidates), deferred backport candidates (--deferred), pending backports (--pending), commits rejected for backport (--rejected), commits that are downstream only (--downstream-only), all commits already backported (--backported), just commits already backported that were non-trivial (--backported-non-trivial), or just commits already backported that were cherry picks (--backported-cherry-picks).
-When no option is given, defaults to listing backport candidates.
+\'list' can display backport candidates (--candidates), deferred backport candidates (--deferred), pending backports (--pending), commits rejected for backport (--rejected), commits that are downstream only (--downstream-only), all commits already backported (--backported), just commits already backported that were non-trivial (--backported-non-trivial), or just commits already backported that were cherry picks (--backported-cherry-picks).
+When none of these options is given, defaults to listing backport candidates.
+.sp
+In addition, options --reverse, --pretty, --oneline and --format are used as in 'git log'.  If no format is specified, 'list' shows commit hashes together with the first line of the commit message and highlights interesting commits (e.g. possible fixes, see CONFIGURATION:abc.should-highlight) when the color.ui configuration setting is true.
+.sp
 <upstream> and <downstream> have the same defaults as 'find'.
-When the color.ui configuration setting is true, interesting commits, e.g. possible fixes, are highlighted.
 .sp
 Note, 'list' only lists commits previously found with 'find', which means <upstream> and <downstream> should bind the same range, or subrange, of the ones used with 'find' and that the search limiting <path>'s used with 'find' also limit what is listed.
 .sp
-When the 'list-fixes' variant is used, only the commits that are highlighted are output (see CONFIGURATION:abc.should-highlight)
+When the 'list-fixes' variant is used, only the "interesting" commits are output.
 .RE
 .PP
 pick-list [<upstream> [<downstream>]]


### PR DESCRIPTION
"git abc list" is using "git log" internally and printing in a format similar to --pretty="%h %s", however sometimes it is useful to change the option format slightly.  There is even already one example in "git abc" itself in the form of "git pick-list".

Add options --oneline, --format and --pretty to "git list" and when they are used invoke git log again to print each commit in the requested format.  While at it add --reverse, which avoids using tac for "git pick-list" but is also useful in general, e.g. with the default --candidates list.